### PR TITLE
changed current_time

### DIFF
--- a/app.py
+++ b/app.py
@@ -695,7 +695,6 @@ default_variables = {
         'nav_bar_header': nav_bar_header,
         'nav_bar_admin_header': nav_bar_admin_header,
         'modules': modules,
-        'current_time': datetime.datetime.now(),
         'request': request,
         'session': session,
         }
@@ -706,6 +705,11 @@ if 'streamtip' in config:
             'redirect_uri': config['streamtip']['redirect_uri'],
             }
 
+@app.context_processor
+def current_time():
+    current_time = {}
+    current_time['current_time'] = datetime.datetime.now()
+    return current_time
 
 @app.context_processor
 def inject_default_variables():


### PR DESCRIPTION
The old **current_time** was the time when the **app.py** started, it never updates.

I changed the way it works, now it's actually the **current time**.

This should fix the **VOD link** for the pleblist and the **calendar** where it's used too.
(never noticed an issue for calendar, but the bot was always restarted every day)

![current_date](http://i.imgur.com/1qilU1T.png)

Tested it and works now for online streams with a video_url :radio:

*With this we can now use `{{current_time|localize|strftime('%A, %B %d %Y %H:%M:%S %Z')}}` to show the current time on the website, if we need this at some point.*