### PR TITLE
Renamed quit to quit_bot

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def run(args):
     pajbot.connect()
 
     def on_sigterm(signal, frame):
-        pajbot.quit()
+        pajbot.quit_bot()
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, on_sigterm)
@@ -46,7 +46,7 @@ def run(args):
     try:
         pajbot.start()
     except KeyboardInterrupt:
-        pajbot.quit()
+        pajbot.quit_bot()
         pass
 
 


### PR DESCRIPTION
Fixed a bug, when you **quit the bot from an app** (pm2) and not from the chat.

I **forgot** to change this code, when i renamed **quit to quit_bot** in PR #191