### PR TITLE
:fire: Updated song_duration for Pleblist / :bank: Updated negativ points settings for raffles

### DIFF
--- a/app.py
+++ b/app.py
@@ -613,7 +613,7 @@ def pleblist_history_stream(stream_id):
         if stream is None:
             return render_template('pleblist_history_404.html'), 404
 
-        songs = session.query(PleblistSong).filter(PleblistSong.stream_id == stream.id).order_by(PleblistSong.date_added.asc(), PleblistSong.date_played.asc()).all()
+        songs = session.query(PleblistSong).filter(PleblistSong.stream_id == stream.id).order_by(PleblistSong.id.asc(), PleblistSong.id.asc()).all()
         total_length_left = sum([song.song_info.duration if song.date_played is None and song.song_info is not None else 0 for song in songs])
 
         first_unplayed_song = find(lambda song: song.date_played is None, songs)

--- a/static/scripts/pleblist.js
+++ b/static/scripts/pleblist.js
@@ -113,9 +113,14 @@ function add_to_pleblist(song)
     $div.append($div_content);
     var title = '???';
     var song_length = '???';
+    if (song.skip_after !== null) {
+        song_duration = song.skip_after;
+        } else {
+        song_duration = song.info.duration;
+        }
     if (song.info !== null) {
         title = song.info.title;
-        song_length = moment.duration(song.info.duration, 'seconds').format('h:mm:ss');
+        song_length = moment.duration(song_duration, 'seconds').format('h:mm:ss');
     }
     $a_header = $('<a>', {class: 'header', 'href': 'https://youtu.be/' + song.youtube_id, }).text(title);
     $div_content.append($a_header);
@@ -143,8 +148,13 @@ function update_song_counter()
     var total_duration = 0;
     for (song_id in pleblist_songs) {
         var song = pleblist_songs[song_id];
+        if (song.skip_after !== null) {
+        song_duration = song.skip_after;
+        } else {
+        song_duration = song.info.duration;
+        }
         if (song.info !== null) {
-            total_duration += song.info.duration;
+            total_duration += song_duration;
         }
     }
     $('#total_duration').text(moment.duration(total_duration, 'seconds').format('h:mm:ss'));

--- a/templates/pleblist_history.html
+++ b/templates/pleblist_history.html
@@ -31,6 +31,13 @@
             Song link: <a href="https://youtu.be/{{ song.youtube_id }}">youtu.be/{{ song.youtube_id }}</a><br/>
             Added: {{ song.date_added|localize|strftime('%Y-%m-%d %H:%M:%S %Z') }}<br />
             {% if song.date_played is not none %}
+            {% if song.skip_after is none %}
+            {% set song_duration = song.song_info.duration %}
+            {% elif song.skip_after is not none %}
+            {% set song_duration = song.skip_after %}
+            {% else %}
+            {% set song_duration = 1 %}
+            {% endif %}
             Played: {{ song.date_played|localize|strftime('%Y-%m-%d %H:%M:%S %Z') }} <em>({{ song.date_played|time_ago}} ago)</em>
             {% for stream_chunk in stream_chunks %}
             {% if stream_chunk.chunk_end is none %}
@@ -38,8 +45,8 @@
             {% else %}
             {% set chunk_end_check = stream_chunk.chunk_end %}
             {% endif %}
-            {% if stream_chunk.chunk_start <= song.date_played <= chunk_end_check and song.song_info and song.song_info.duration <= 600 and stream_chunk.video_url != none %}
-            {% set vod_time_in_seconds = (song.date_played - stream_chunk.chunk_start).total_seconds() - song.song_info.duration %}
+            {% if stream_chunk.chunk_start <= song.date_played <= chunk_end_check and song.song_info and song_duration <= 601 and stream_chunk.video_url != none %}
+            {% set vod_time_in_seconds = (song.date_played - stream_chunk.chunk_start).total_seconds() - song_duration %}
             <br />VOD link: <a href="{{stream_chunk.video_url}}?t={{ vod_time_in_seconds|seconds_to_vodtime }}">{{stream_chunk.video_url}}?t={{ vod_time_in_seconds|seconds_to_vodtime }}</a>
             {% else %}{% endif %}
             {% endfor %}
@@ -51,7 +58,7 @@
             Playing now!
             {% endif %}
             {% set num_not_played = num_not_played + 1 %}
-            {% set time_until_song_played = time_until_song_played + song.song_info.duration %}
+            {% set time_until_song_played = time_until_song_played + song_duration %}
             {% endif %}
             {% endif %}
         </div>


### PR DESCRIPTION
:fire: **Updated song_duration for Pleblist**
You now see the **real song_duration / total duration** if you used the skip after **6 or 10** minutes button.

I hope i don't break old code, but i think it should be fine :)

Sorted the pleblist after id not date_added

Also we can close 114, we don't need to hide skipped songs.
Fixed #114 
<br/><br/>
:bank: **Updated negativ points settings for raffles**
Added a **setting** where you can **disable negative** raffles.
Or add a **limit** so mods can't start -1M raffles, to fuck up points from other people.

This doesn't closes 1 7 1 but it helps.

#171 