### PR TITLE
Subalert supports whispers now

### DIFF
--- a/pajbot/modules/subalert.py
+++ b/pajbot/modules/subalert.py
@@ -12,13 +12,19 @@ class SubAlertModule(BaseModule):
 
     ID = __name__.split('.')[-1]
     NAME = 'Subscription Alert (text)'
-    DESCRIPTION = 'Prints a message in chat for someone who subscribed'
+    DESCRIPTION = 'Prints a message in chat or a whisper for someone who subscribed'
     CATEGORY = 'Feature'
     ENABLED_DEFAULT = True
     SETTINGS = [
             ModuleSetting(
+                key='chat_message',
+                label='Enable a chat message for someone who subscribed',
+                type='boolean',
+                required=True,
+                default=True),
+            ModuleSetting(
                 key='new_sub',
-                label='New sub',
+                label='New sub chat message | Available arguments: {username}',
                 type='text',
                 required=True,
                 placeholder='Sub hype! {username} just subscribed PogChamp',
@@ -29,11 +35,50 @@ class SubAlertModule(BaseModule):
                     }),
             ModuleSetting(
                 key='resub',
-                label='Resub',
+                label='Resub chat message | Available arguments: {username}, {num_months}',
                 type='text',
                 required=True,
-                placeholder='Resub hype! {username} just subscribed, {num_months} months in a row PogChamp <3 PogChamp',
-                default='Resub hype! {username} just subscribed, {num_months} months in a row PogChamp <3 PogChamp',
+                placeholder='Resub hype! {username} just subscribed, {num_months} months in a row PogChamp <3',
+                default='Resub hype! {username} just subscribed, {num_months} months in a row PogChamp <3',
+                constraints={
+                    'min_str_len': 10,
+                    'max_str_len': 400,
+                    }),
+            ModuleSetting(
+                key='whisper_message',
+                label='Enable a whisper message for someone who subscribed',
+                type='boolean',
+                required=True,
+                default=False),
+            ModuleSetting(
+                key='whisper_after',
+                label='Whisper the message after X seconds',
+                type='number',
+                required=True,
+                placeholder='',
+                default=5,
+                constraints={
+                    'min_value': 1,
+                    'max_value': 120,
+                    }),
+            ModuleSetting(
+                key='new_sub_whisper',
+                label='Whisper message for new subs | Available arguments: {username}',
+                type='text',
+                required=True,
+                placeholder='Thank you for subscribing {username} <3',
+                default='Thank you for subscribing {username} <3',
+                constraints={
+                    'min_str_len': 10,
+                    'max_str_len': 400,
+                    }),
+            ModuleSetting(
+                key='resub_whisper',
+                label='Whisper message for resubs | Available arguments: {username}, {num_months}',
+                type='text',
+                required=True,
+                placeholder='Thank you for subscribing for {num_months} months in a row {username} <3',
+                default='Thank you for subscribing for {num_months} months in a row {username} <3',
                 constraints={
                     'min_str_len': 10,
                     'max_str_len': 400,
@@ -57,7 +102,11 @@ class SubAlertModule(BaseModule):
         payload = {'username': user.username_raw}
         self.bot.websocket_manager.emit('new_sub', payload)
 
-        self.bot.say(self.get_phrase('new_sub', **payload))
+        if self.settings['chat_message'] is True:
+            self.bot.say(self.get_phrase('new_sub', **payload))
+
+        if self.settings['whisper_message'] is True:
+            self.bot.execute_delayed(self.settings['whisper_after'], self.bot.whisper, (user.username, self.get_phrase('new_sub_whisper', **payload)), )
 
     def on_resub(self, user, num_months):
         """
@@ -68,7 +117,11 @@ class SubAlertModule(BaseModule):
         payload = {'username': user.username_raw, 'num_months': num_months}
         self.bot.websocket_manager.emit('resub', payload)
 
-        self.bot.say(self.get_phrase('resub', **payload))
+        if self.settings['chat_message'] is True:
+            self.bot.say(self.get_phrase('resub', **payload))
+
+        if self.settings['whisper_message'] is True:
+            self.bot.execute_delayed(self.settings['whisper_after'], self.bot.whisper, (user.username, self.get_phrase('resub_whisper', **payload)), )
 
     def on_message(self, source, message, emotes, whisper, urls, event):
         if whisper is False and source.username == 'twitchnotify':


### PR DESCRIPTION
Added a feature where you can **whisper a message** to new subs / resubs when they sub,

you can turn off chat messages and **only use the whisper** message or **run both** or **only chat** messages.

![preview](http://i.imgur.com/ddmlXAg.png)

Would fix #221 