### PR TITLE
More for Dubtrack module

### DIFF
--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -1,3 +1,4 @@
+import html
 import json
 import logging
 import re
@@ -119,7 +120,8 @@ class DubtrackModule(BaseModule):
             # No need to update song
             return
 
-        self.song_name = data['name']
+        raw_song_name = data['name']
+        self.song_name = html.unescape(raw_song_name)
         self.song_id = data['songid']
 
         if data['type'] == 'youtube':

--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -99,18 +99,24 @@ class DubtrackModule(BaseModule):
 
         r = requests.get(url)
         if r.status_code != 200:
+            log.warning('Dubtrack api not responding')
+            self.clear()
             return
 
         text = json.loads(r.text)
         if text['code'] != 200:
+            log.warning('Dubtrack api invalid response')
+            self.clear()
             return
 
         data = text['data']['currentSong']
         if data is None:
+            # No song playing
             self.clear()
             return
 
         if self.song_id == data['songid']:
+            # No need to update song
             return
 
         self.song_name = data['name']
@@ -123,12 +129,14 @@ class DubtrackModule(BaseModule):
 
             r = requests.get(url, allow_redirects=False)
             if r.status_code != 301:
+                log.warning('Couldn\'t resolve soundcloud link')
                 self.song_link = None
                 return
 
             new_song_link = r.headers['Location']
             self.song_link = re.sub('^http', 'https', new_song_link)
         else:
+            log.warning('Unknown link type')
             self.song_link = None
 
     def say_song(self, bot):

--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -27,9 +27,20 @@ class DubtrackModule(BaseModule):
                 placeholder='Dubtrack room (i.e. pajlada)',
                 default='pajlada',
                 constraints={
-                    'min_str_len': 2,
+                    'min_str_len': 1,
                     'max_str_len': 70,
                     }),
+            ModuleSetting(
+                key='phrase_room_link',
+                label='Room link message | Available arguments: {room_name}',
+                type='text',
+                required=True,
+                placeholder='Request your songs at https://dubtrack.fm/join/{room_name}',
+                default='Request your songs at https://dubtrack.fm/join/{room_name}',
+                constraints={
+                    'min_str_len': 1,
+                    'max_str_len': 400,
+                }),
             ModuleSetting(
                 key='phrase_current_song',
                 label='Current song message | Available arguments: {song_name}, {song_link}',
@@ -38,7 +49,7 @@ class DubtrackModule(BaseModule):
                 placeholder='Current song: {song_name}, link: {song_link}',
                 default='Current song: {song_name}, link: {song_link}',
                 constraints={
-                    'min_str_len': 10,
+                    'min_str_len': 1,
                     'max_str_len': 400,
                 }),
             ModuleSetting(
@@ -49,18 +60,7 @@ class DubtrackModule(BaseModule):
                 placeholder='Current song: {song_name}',
                 default='Current song: {song_name}',
                 constraints={
-                    'min_str_len': 10,
-                    'max_str_len': 400,
-                }),
-            ModuleSetting(
-                key='phrase_room_link',
-                label='Room link message | Available arguments: {room_name}',
-                type='text',
-                required=True,
-                placeholder='Request your songs at https://dubtrack.fm/join/{room_name}',
-                default='Request your songs at https://dubtrack.fm/join/{room_name}',
-                constraints={
-                    'min_str_len': 10,
+                    'min_str_len': 1,
                     'max_str_len': 400,
                 }),
             ModuleSetting(
@@ -71,9 +71,31 @@ class DubtrackModule(BaseModule):
                 placeholder='There\'s no song playing right now FeelsBadMan',
                 default='There\'s no song playing right now FeelsBadMan',
                 constraints={
-                    'min_str_len': 2,
+                    'min_str_len': 1,
                     'max_str_len': 400,
                 }),
+            ModuleSetting(
+                key='global_cd',
+                label='Global cooldown (seconds)',
+                type='number',
+                required=True,
+                placeholder='',
+                default=5,
+                constraints={
+                    'min_value': 0,
+                    'max_value': 120,
+                    }),
+            ModuleSetting(
+                key='user_cd',
+                label='Per-user cooldown (seconds)',
+                type='number',
+                required=True,
+                placeholder='',
+                default=15,
+                constraints={
+                    'min_value': 0,
+                    'max_value': 240,
+                    }),
                 ]
 
     def __init__(self, **options):
@@ -169,24 +191,25 @@ class DubtrackModule(BaseModule):
                 'link': Command.raw_command(
                     self.link,
                     level=100,
-                    delay_all=5,
-                    delay_user=15,
+                    delay_all=self.settings['global_cd'],
+                    delay_user=self.settings['user_cd'],
                     description='Get link to your dubtrack',
                 ),
                 'song': Command.raw_command(
                     self.song,
                     level=100,
-                    delay_all=5,
-                    delay_user=15,
+                    delay_all=self.settings['global_cd'],
+                    delay_user=self.settings['user_cd'],
                     description='Get current song',
                     run_in_thread=True,
                     ),
                 'update': Command.raw_command(
                     self.update,
                     level=500,
-                    delay_all=0,
-                    delay_user=0,
+                    delay_all=self.settings['global_cd'],
+                    delay_user=self.settings['user_cd'],
                     description='Force reloading the song and get current song',
+                    run_in_thread=True,
                     ),
                 }
         commands['l'] = commands['link']

--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -62,6 +62,17 @@ class DubtrackModule(BaseModule):
                     'min_str_len': 10,
                     'max_str_len': 400,
                 }),
+            ModuleSetting(
+                key='phrase_no_current_song',
+                label='Current song message when there\'s nothing playing',
+                type='text',
+                required=True,
+                placeholder='There\'s no song playing right now FeelsBadMan',
+                default='There\'s no song playing right now FeelsBadMan',
+                constraints={
+                    'min_str_len': 2,
+                    'max_str_len': 400,
+                }),
                 ]
 
     def __init__(self, **options):
@@ -122,7 +133,7 @@ class DubtrackModule(BaseModule):
 
     def say_song(self, bot):
         if self.song_name is None:
-            bot.say('There\'s no song playing right now FeelsBadMan')
+            bot.say(self.get_phrase('phrase_no_current_song'))
             return
 
         arguments = {

--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -6,6 +6,7 @@ import re
 import requests
 
 from pajbot.models.command import Command
+from pajbot.models.command import CommandExample
 from pajbot.modules import BaseModule
 from pajbot.modules import ModuleSetting
 
@@ -151,10 +152,11 @@ class DubtrackModule(BaseModule):
         elif data['type'] == 'soundcloud':
             url = 'https://api.dubtrack.fm/song/' + data['songid'] + '/redirect'
 
+            self.song_link = None
+
             r = requests.get(url, allow_redirects=False)
             if r.status_code != 301:
                 log.warning('Couldn\'t resolve soundcloud link')
-                self.song_link = None
                 return
 
             new_song_link = r.headers['Location']
@@ -194,7 +196,14 @@ class DubtrackModule(BaseModule):
                     delay_all=self.settings['global_cd'],
                     delay_user=self.settings['user_cd'],
                     description='Get link to your dubtrack',
-                ),
+                    examples=[
+                        CommandExample(
+                            None,
+                            'Ask bot for dubtrack link',
+                            chat='user:!dubtrack link\n'
+                            'bot:Request your songs at https://dubtrack.fm/join/pajlada').parse(),
+                        ],
+                    ),
                 'song': Command.raw_command(
                     self.song,
                     level=100,
@@ -202,6 +211,23 @@ class DubtrackModule(BaseModule):
                     delay_user=self.settings['user_cd'],
                     description='Get current song',
                     run_in_thread=True,
+                    examples=[
+                        CommandExample(
+                            None,
+                            'Ask bot for current song (youtube)',
+                            chat='user:!dubtrack song\n'
+                            'bot:Current song: NOMA - Brain Power, link: https://youtu.be/9R8aSKwTEMg').parse(),
+                        CommandExample(
+                            None,
+                            'Ask bot for current song (soundcloud)',
+                            chat='user:!dubtrack song\n'
+                            'bot:Current song: This is Bondage, link: https://soundcloud.com/razq35/nightlife').parse(),
+                        CommandExample(
+                            None,
+                            'Ask bot for current song (nothing playing)',
+                            chat='user:!dubtrack song\n'
+                            'bot:There\'s no song playing right now FeelsBadMan').parse(),
+                        ],
                     ),
                 'update': Command.raw_command(
                     self.update,

--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -97,6 +97,27 @@ class DubtrackModule(BaseModule):
                     'min_value': 0,
                     'max_value': 240,
                     }),
+            ModuleSetting(
+                key='if_dt_alias',
+                label='Allow !dt as !dubtrack',
+                type='boolean',
+                required=True,
+                default=True,
+                    ),
+            ModuleSetting(
+                key='if_short_alias',
+                label='Allow !dubtrack [s, l, u] as !dubtrack [song, link, update]',
+                type='boolean',
+                required=True,
+                default=True,
+                    ),
+            ModuleSetting(
+                key='if_song_alias',
+                label='Allow !song as !dubtrack song',
+                type='boolean',
+                required=True,
+                default=True,
+                    ),
                 ]
 
     def __init__(self, **options):
@@ -238,9 +259,10 @@ class DubtrackModule(BaseModule):
                     run_in_thread=True,
                     ),
                 }
-        commands['l'] = commands['link']
-        commands['s'] = commands['song']
-        commands['u'] = commands['update']
+        if self.settings['if_short_alias']:
+            commands['l'] = commands['link']
+            commands['s'] = commands['song']
+            commands['u'] = commands['update']
 
         self.commands['dubtrack'] = Command.multiaction_command(
             level=100,
@@ -249,5 +271,9 @@ class DubtrackModule(BaseModule):
             command='dubtrack',
             commands=commands,
             )
-        self.commands['dt'] = self.commands['dubtrack']
-        self.commands['song'] = commands['song']
+
+        if self.settings['if_dt_alias']:
+            self.commands['dt'] = self.commands['dubtrack']
+
+        if self.settings['if_song_alias']:
+            self.commands['song'] = commands['song']


### PR DESCRIPTION
A few little thing to enhance my lovely module. I tested them on a website and everything looks fine. Also everything should be flake8proof :)

From my testing: If a soundcloud song is playing on dubtrack and the api calls weren't made (fresh or outdated song).
The first `!dubtrack song` will last longer (because of second api call), but if you call `!dubtrack song` again, before the first one finishes, the second call will return a song without link. The first call will return second, with a link.
Is there a way to delay the second (and more) calls?

Another problem that I have no idea how to deal is on the website in Commands tab. When I have a `!dubtrack` command that is the same as `!song` and `!dubtrack link`. Only one commands shows in the list (seems random). Maybe it has something to do with the ID. What ID can I give to my commands so it won't interfere with user made commands?