### PR TITLE
Custom raffle message + Hide messages on clr overlay

### DIFF
--- a/pajbot/models/command.py
+++ b/pajbot/models/command.py
@@ -106,7 +106,7 @@ class CommandData(Base):
         self.num_uses = 0
         self.added_by = None
         self.edited_by = None
-        self.last_date_used = 0
+        self.last_date_used = None
 
         self.set(**options)
 

--- a/pajbot/modules/duel.py
+++ b/pajbot/modules/duel.py
@@ -82,6 +82,12 @@ class DuelModule(BaseModule):
                     'min_value': 0,
                     'max_value': 240,
                     }),
+            ModuleSetting(
+                key='show_on_clr',
+                label='Show duels on the clr overlay',
+                type='boolean',
+                required=True,
+                default=True),
                 ]
 
     def load_commands(self, **options):
@@ -257,7 +263,7 @@ class DuelModule(BaseModule):
 
             if source.duel_price > 0:
                 message = self.get_phrase('message_won_points', **arguments)
-                if source.duel_price >= 500:
+                if source.duel_price >= 500 and self.settings['show_on_clr']:
                     bot.websocket_manager.emit('notification', {'message': '{} won the duel vs {}'.format(winner.username_raw, loser.username_raw)})
             else:
                 message = self.get_phrase('message_won', **arguments)

--- a/pajbot/modules/paidtimeout.py
+++ b/pajbot/modules/paidtimeout.py
@@ -101,6 +101,12 @@ class PaidTimeoutModule(BaseModule):
                     'min_value': 100,
                     'max_value': 1000,
                     }),
+            ModuleSetting(
+                key='show_on_clr',
+                label='Show timeouts on the clr overlay',
+                type='boolean',
+                required=True,
+                default=True),
             ]
 
     def base_paid_timeout(self, bot, source, message, _time, _cost):
@@ -152,8 +158,9 @@ class PaidTimeoutModule(BaseModule):
             victim.timeout_start = now
             victim.timeout_end = now + datetime.timedelta(seconds=_time)
 
-        payload = {'user': source.username, 'victim': victim.username}
-        bot.websocket_manager.emit('timeout', payload)
+        if self.settings['show_on_clr']:
+            payload = {'user': source.username, 'victim': victim.username}
+            bot.websocket_manager.emit('timeout', payload)
         HandlerManager.trigger('on_paid_timeout',
                 source, victim, _cost,
                 stop_on_false=False)


### PR DESCRIPTION
**Boolean** to hide on the **clr overlay**
- Hide duels
- Hide paidtimeouts
- Hide raffles
If the streamer changes the cam to the bottom left and
people don't realy read it on the overlay, sometimes it should be just turned off.

**Custom raffle messages**, the arguments looks a bit weird.
But at least you can get a custom message with the right times.

It's there to stop the autojoin bots.
It looks so bad for the streamer if there are bots in his channel.
- Chat is slow and out of nowhere there are people who type !join and don't do anything else.
- Or there is a wall of !join at the same time, like spam bots.

Fixed a **small bug** for **python 3.5** where it must be None not 0 :P

Not sure what you changed for usersettings for points. But i hope this will work with it :D