### PR TITLE
Add python3 module back to uwsgi_shared.ini for older uwsgi versions

### DIFF
--- a/uwsgi_shared.ini
+++ b/uwsgi_shared.ini
@@ -13,6 +13,6 @@ chmod-socket = 777
 vacuum = true
 die-on-term = true
 
-plugins = router_cache
+plugins = python3,router_cache
 
 memory-report = true


### PR DESCRIPTION
My uwsgi version is `2.0.14-debian` from the debian 9 stable (stretch) repository.